### PR TITLE
Handle Right/Left in PathFinderForm

### DIFF
--- a/frontend/src/components/PathFinderForm.tsx
+++ b/frontend/src/components/PathFinderForm.tsx
@@ -73,12 +73,15 @@ export default function PathFinderForm() {
         throw new Error(`HTTP error: ${resp.status}`);
       }
 
-      const body = (await resp.json()) as PathResponse | ErrorResponse;
-
-      if ("errMessage" in body) {
-        setError(body.errMessage);
+      const json = await resp.json();
+      if ("Right" in json) {
+        setResult(json.Right as PathResponse);
+      } else if ("Left" in json) {
+        setError((json.Left as ErrorResponse).errMessage);
+      } else if ("errMessage" in json) {
+        setError((json as ErrorResponse).errMessage);
       } else {
-        setResult(body);
+        setResult(json as PathResponse);
       }
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- support `Right` and `Left` wrappers in API responses

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f4c1e43608330aff192c380ef393b