### PR TITLE
Translate frontend to Spanish

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,13 +2,13 @@ import "./globals.css";
 import type { ReactNode } from "react";
 
 export const metadata = {
-  title: "Magical Runes Forest - PathFinder Game",
-  description: "Find the optimal energy path through the magical forest",
+  title: "Bosque de Runas Mágicas - Juego de Búsqueda de Ruta",
+  description: "Encuentra la ruta de energía óptima a través del bosque mágico",
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="es">
       <body className="bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-50 min-h-screen">
         {children}
       </body>

--- a/frontend/src/components/GameInstructions.tsx
+++ b/frontend/src/components/GameInstructions.tsx
@@ -9,14 +9,14 @@ export default function GameInstructions() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Target className="w-5 h-5 text-purple-600" />
-            Game Objective
+            Objetivo del Juego
           </CardTitle>
         </CardHeader>
         <CardContent>
           <p className="text-gray-700">
-            Navigate through the magical forest from the top-left corner to the
-            bottom-right corner, finding the path that maximizes your energy.
-            Each rune tile will either boost or drain your magical power!
+            Recorre el bosque mágico desde la esquina superior izquierda hasta
+            la inferior derecha buscando la ruta que maximice tu energía. Cada
+            loseta de runa aumentará o reducirá tu poder mágico.
           </p>
         </CardContent>
       </Card>
@@ -25,7 +25,7 @@ export default function GameInstructions() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Zap className="w-5 h-5 text-yellow-500" />
-            How Energy Works
+            Cómo Funciona la Energía
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -35,8 +35,8 @@ export default function GameInstructions() {
                 <Plus className="w-4 h-4" />
               </Badge>
               <div>
-                <strong>Positive Numbers:</strong> Boost your energy (e.g., +3
-                adds 3 energy points)
+                <strong>Números positivos:</strong> Aumentan tu energía (p.ej.,
+                +3 suma 3 puntos de energía)
               </div>
             </div>
             <div className="flex items-center gap-3">
@@ -44,8 +44,8 @@ export default function GameInstructions() {
                 <Minus className="w-4 h-4" />
               </Badge>
               <div>
-                <strong>Negative Numbers:</strong> Drain your energy (e.g., -2
-                removes 2 energy points)
+                <strong>Números negativos:</strong> Reducen tu energía (p.ej., -2
+                resta 2 puntos)
               </div>
             </div>
             <div className="flex items-center gap-3">
@@ -53,7 +53,7 @@ export default function GameInstructions() {
                 0
               </Badge>
               <div>
-                <strong>Zero:</strong> No effect on your energy
+                <strong>Cero:</strong> No afecta tu energía
               </div>
             </div>
           </div>
@@ -62,7 +62,7 @@ export default function GameInstructions() {
 
       <Card>
         <CardHeader>
-          <CardTitle>How to Play</CardTitle>
+          <CardTitle>Cómo Jugar</CardTitle>
         </CardHeader>
         <CardContent>
           <ol className="space-y-3 text-gray-700">
@@ -71,8 +71,8 @@ export default function GameInstructions() {
                 1
               </Badge>
               <div>
-                <strong>Set Starting Energy:</strong> Choose how much energy you
-                begin with (recommended: 10-20)
+                <strong>Establece la energía inicial:</strong> Elige cuánta
+                energía tendrás al comenzar (recomendado: 10-20)
               </div>
             </li>
             <li className="flex items-start gap-3">
@@ -80,8 +80,9 @@ export default function GameInstructions() {
                 2
               </Badge>
               <div>
-                <strong>Edit the Grid:</strong> Click on any tile to change its
-                energy value, or use presets to get started
+                <strong>Edita la cuadrícula:</strong> Haz clic en cualquier
+                casilla para cambiar su valor de energía o usa los modelos
+                predefinidos
               </div>
             </li>
             <li className="flex items-start gap-3">
@@ -89,8 +90,9 @@ export default function GameInstructions() {
                 3
               </Badge>
               <div>
-                <strong>Find the Path:</strong> Click &quot;Find Optimal
-                Path&quot; to calculate the best route
+                <strong>Encuentra la ruta:</strong> Haz clic en
+                &quot;Encontrar Ruta Óptima&quot; para calcular el mejor
+                recorrido
               </div>
             </li>
             <li className="flex items-start gap-3">
@@ -98,8 +100,8 @@ export default function GameInstructions() {
                 4
               </Badge>
               <div>
-                <strong>View Results:</strong> The optimal path will be
-                highlighted on the grid with numbered steps
+                <strong>Ver resultados:</strong> La ruta óptima se
+                resaltará en la cuadrícula con pasos numerados
               </div>
             </li>
           </ol>
@@ -108,25 +110,26 @@ export default function GameInstructions() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Tips for Success</CardTitle>
+          <CardTitle>Consejos para el Éxito</CardTitle>
         </CardHeader>
         <CardContent>
           <ul className="space-y-2 text-gray-700">
             <li className="flex items-center gap-2">
               <ArrowRight className="w-4 h-4 text-purple-600" />
-              Start with preset grids to learn the game mechanics
+              Comienza con las cuadrículas predefinidas para aprender la mecánica
             </li>
             <li className="flex items-center gap-2">
               <ArrowRight className="w-4 h-4 text-purple-600" />
-              Higher starting energy gives you more flexibility
+              Una energía inicial mayor te da más flexibilidad
             </li>
             <li className="flex items-center gap-2">
               <ArrowRight className="w-4 h-4 text-purple-600" />
-              Try creating grids with different patterns to see how paths change
+              Prueba a crear cuadrículas con distintos patrones para ver cómo
+              cambian las rutas
             </li>
             <li className="flex items-center gap-2">
               <ArrowRight className="w-4 h-4 text-purple-600" />
-              The algorithm finds the mathematically optimal path automatically
+              El algoritmo encuentra automáticamente la ruta óptima
             </li>
           </ul>
         </CardContent>

--- a/frontend/src/components/GridEditor.tsx
+++ b/frontend/src/components/GridEditor.tsx
@@ -78,7 +78,7 @@ export default function GridEditor({
       <div className="flex flex-wrap gap-2">
         <Button onClick={increaseSize} size="sm" variant="outline">
           <Plus className="w-4 h-4 mr-1" />
-          Increase Size
+          Aumentar Tamaño
         </Button>
         <Button
           onClick={decreaseSize}
@@ -87,7 +87,7 @@ export default function GridEditor({
           disabled={grid.length <= 2}
         >
           <Minus className="w-4 h-4 mr-1" />
-          Decrease Size
+          Reducir Tamaño
         </Button>
       </div>
 
@@ -134,7 +134,7 @@ export default function GridEditor({
       {editingCell && (
         <div className="flex items-center gap-2 p-3 bg-gray-50 rounded-lg">
           <span className="text-sm">
-            Edit cell ({editingCell[0]}, {editingCell[1]}):
+            Editar celda ({editingCell[0]}, {editingCell[1]}):
           </span>
           <input
             type="number"
@@ -150,7 +150,7 @@ export default function GridEditor({
             autoFocus
           />
           <Button size="sm" onClick={() => setEditingCell(null)}>
-            Done
+            Hecho
           </Button>
         </div>
       )}
@@ -159,29 +159,29 @@ export default function GridEditor({
       <div className="flex flex-wrap gap-4 text-xs text-gray-600">
         <div className="flex items-center gap-1">
           <div className="w-3 h-3 bg-green-100 border border-green-300 rounded"></div>
-          <span>Positive (Energy Boost)</span>
+          <span>Positivo (Aumenta Energía)</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-3 h-3 bg-red-100 border border-red-300 rounded"></div>
-          <span>Negative (Energy Drain)</span>
+          <span>Negativo (Reduce Energía)</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-3 h-3 bg-gray-100 border border-gray-300 rounded"></div>
-          <span>Neutral</span>
+          <span>Neutro</span>
         </div>
         {path && (
           <>
             <div className="flex items-center gap-1">
               <div className="w-3 h-3 bg-green-500 rounded"></div>
-              <span>Start</span>
+              <span>Inicio</span>
             </div>
             <div className="flex items-center gap-1">
               <div className="w-3 h-3 bg-blue-500 rounded"></div>
-              <span>Path</span>
+              <span>Camino</span>
             </div>
             <div className="flex items-center gap-1">
               <div className="w-3 h-3 bg-red-500 rounded"></div>
-              <span>End</span>
+              <span>Fin</span>
             </div>
           </>
         )}

--- a/frontend/src/components/PathFinderGame.tsx
+++ b/frontend/src/components/PathFinderGame.tsx
@@ -70,7 +70,7 @@ export default function PathFinderGame() {
 
       setShowPath(true);
     } catch {
-      setError("Failed to find optimal path. Please try again.");
+      setError("No se pudo encontrar la ruta óptima. Inténtalo de nuevo.");
     } finally {
       setLoading(false);
     }
@@ -95,14 +95,13 @@ export default function PathFinderGame() {
         <div className="flex items-center justify-center gap-2 mb-4">
           <Sparkles className="w-8 h-8 text-purple-600" />
           <h1 className="text-4xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">
-            Magical Runes Forest
+            Bosque de Runas Mágicas
           </h1>
           <Sparkles className="w-8 h-8 text-purple-600" />
         </div>
         <p className="text-lg text-gray-600 max-w-2xl mx-auto">
-          Navigate through the enchanted forest to find the path that maximizes
-          your magical energy. Each rune tile will either boost or drain your
-          power!
+          Navega por el bosque encantado para encontrar el camino que maximice
+          tu energía mágica. Cada loseta de runa aumentará o drenará tu poder.
         </p>
       </div>
 
@@ -113,15 +112,15 @@ export default function PathFinderGame() {
             <TabsList className="grid w-full grid-cols-3">
               <TabsTrigger value="play" className="flex items-center gap-2">
                 <Play className="w-4 h-4" />
-                Play
+                Jugar
               </TabsTrigger>
               <TabsTrigger value="presets" className="flex items-center gap-2">
                 <Target className="w-4 h-4" />
-                Presets
+                Modelos
               </TabsTrigger>
               <TabsTrigger value="help" className="flex items-center gap-2">
                 <Lightbulb className="w-4 h-4" />
-                How to Play
+                Cómo Jugar
               </TabsTrigger>
             </TabsList>
 
@@ -131,7 +130,7 @@ export default function PathFinderGame() {
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <Zap className="w-5 h-5 text-yellow-500" />
-                    Starting Energy
+                    Energía Inicial
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
@@ -147,7 +146,7 @@ export default function PathFinderGame() {
                       max="100"
                     />
                     <span className="text-sm text-gray-600">
-                      Energy points to start your journey
+                      Puntos de energía para comenzar tu aventura
                     </span>
                   </div>
                 </CardContent>
@@ -156,10 +155,11 @@ export default function PathFinderGame() {
               {/* Grid Editor */}
               <Card>
                 <CardHeader>
-                  <CardTitle>Forest Grid</CardTitle>
+                  <CardTitle>Cuadrícula del Bosque</CardTitle>
                   <p className="text-sm text-gray-600">
-                    Click on tiles to edit their energy values. Positive numbers
-                    boost energy, negative numbers drain it.
+                    Haz clic en las casillas para editar sus valores de energía.
+                    Los números positivos aumentan la energía y los negativos la
+                    reducen.
                   </p>
                 </CardHeader>
                 <CardContent>
@@ -182,18 +182,18 @@ export default function PathFinderGame() {
                   {loading ? (
                     <>
                       <div className="animate-spin rounded-full h-4 w-4 border-2 border-white border-t-transparent mr-2" />
-                      Finding Path...
+                      Buscando Ruta...
                     </>
                   ) : (
                     <>
                       <Target className="w-4 h-4 mr-2" />
-                      Find Optimal Path
+                      Encontrar Ruta Óptima
                     </>
                   )}
                 </Button>
                 <Button onClick={handleReset} variant="outline" size="lg">
                   <RotateCcw className="w-4 h-4 mr-2" />
-                  Reset
+                  Reiniciar
                 </Button>
               </div>
             </TabsContent>
@@ -215,30 +215,30 @@ export default function PathFinderGame() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Zap className="w-5 h-5 text-yellow-500" />
-                Game Status
+                Estado del Juego
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
               <div className="flex justify-between items-center">
-                <span className="text-sm text-gray-600">Grid Size:</span>
+                <span className="text-sm text-gray-600">Tamaño de la Cuadrícula:</span>
                 <Badge variant="secondary">
                   {grid.length}×{grid[0]?.length || 0}
                 </Badge>
               </div>
               <div className="flex justify-between items-center">
-                <span className="text-sm text-gray-600">Starting Energy:</span>
+                <span className="text-sm text-gray-600">Energía Inicial:</span>
                 <Badge className="bg-yellow-100 text-yellow-800">
                   {initialEnergy}
                 </Badge>
               </div>
               <div className="flex justify-between items-center">
-                <span className="text-sm text-gray-600">Status:</span>
+                <span className="text-sm text-gray-600">Estado:</span>
                 <Badge variant={result ? "default" : "secondary"}>
                   {loading
-                    ? "Calculating..."
+                    ? "Calculando..."
                     : result
-                    ? "Path Found!"
-                    : "Ready"}
+                    ? "\u00a1Ruta Encontrada!"
+                    : "Listo"}
                 </Badge>
               </div>
             </CardContent>
@@ -260,28 +260,28 @@ export default function PathFinderGame() {
               <CardHeader>
                 <CardTitle className="text-green-800 flex items-center gap-2">
                   <Target className="w-5 h-5" />
-                  Optimal Path Found!
+                  ¡Ruta Óptima Encontrada!
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="space-y-2">
                   <div className="flex justify-between items-center">
-                    <span className="text-sm text-green-700">Path Length:</span>
+                    <span className="text-sm text-green-700">Longitud de la Ruta:</span>
                     <Badge className="bg-green-100 text-green-800">
-                      {result.prPath.length} steps
+                      {result.prPath.length} pasos
                     </Badge>
                   </div>
                   <div className="flex justify-between items-center">
                     <span className="text-sm text-green-700">
-                      Final Energy:
+                      Energía Final:
                     </span>
                     <Badge className="bg-green-100 text-green-800">
-                      {result.prFinalEnergy} points
+                      {result.prFinalEnergy} puntos
                     </Badge>
                   </div>
                   <div className="flex justify-between items-center">
                     <span className="text-sm text-green-700">
-                      Energy Gained:
+                      Energía Obtenida:
                     </span>
                     <Badge className="bg-green-100 text-green-800">
                       +{result.prFinalEnergy - initialEnergy}
@@ -291,7 +291,7 @@ export default function PathFinderGame() {
 
                 <div className="pt-2 border-t border-green-200">
                   <p className="text-xs text-green-600 mb-2">
-                    Path coordinates:
+                    Coordenadas de la ruta:
                   </p>
                   <div className="flex flex-wrap gap-1">
                     {result.prPath.map((coord, index) => (

--- a/frontend/src/components/PresetGrids.tsx
+++ b/frontend/src/components/PresetGrids.tsx
@@ -11,19 +11,19 @@ interface PresetGridsProps {
 
 const presets = [
   {
-    name: "Beginner Forest",
-    description: "A simple 3×3 grid perfect for learning",
+    name: "Bosque Principiante",
+    description: "Una cuadricula 3×3 sencilla para aprender",
     grid: [
       [1, -1, 2],
       [0, 3, -2],
       [2, 1, 4],
     ],
     energy: 8,
-    difficulty: "Easy",
+    difficulty: "Fácil",
   },
   {
-    name: "Enchanted Path",
-    description: "Medium difficulty with mixed energy zones",
+    name: "Senda Encantada",
+    description: "Dificultad media con zonas de energía mixtas",
     grid: [
       [2, -1, 0, 3],
       [1, 4, -3, 2],
@@ -31,11 +31,11 @@ const presets = [
       [3, -2, 2, 1],
     ],
     energy: 12,
-    difficulty: "Medium",
+    difficulty: "Media",
   },
   {
-    name: "Dragon's Lair",
-    description: "Challenging 5×5 grid with high stakes",
+    name: "Guarida del Dragón",
+    description: "Cuadrícula 5×5 desafiante de alto riesgo",
     grid: [
       [3, -2, 1, -4, 2],
       [-1, 5, -3, 1, -2],
@@ -44,11 +44,11 @@ const presets = [
       [1, -4, 2, -1, 5],
     ],
     energy: 15,
-    difficulty: "Hard",
+    difficulty: "Difícil",
   },
   {
-    name: "Mystic Maze",
-    description: "Complex 6×6 grid for experts",
+    name: "Laberinto Místico",
+    description: "Compleja cuadrícula 6×6 para expertos",
     grid: [
       [2, -3, 1, 4, -2, 3],
       [-1, 5, -4, 2, 1, -3],
@@ -58,20 +58,20 @@ const presets = [
       [-2, 4, -3, 2, -1, 7],
     ],
     energy: 20,
-    difficulty: "Expert",
+    difficulty: "Experto",
   },
 ];
 
 export default function PresetGrids({ onLoadPreset }: PresetGridsProps) {
   const getDifficultyColor = (difficulty: string) => {
     switch (difficulty) {
-      case "Easy":
+      case "Fácil":
         return "bg-green-100 text-green-800";
-      case "Medium":
+      case "Media":
         return "bg-yellow-100 text-yellow-800";
-      case "Hard":
+      case "Difícil":
         return "bg-orange-100 text-orange-800";
-      case "Expert":
+      case "Experto":
         return "bg-red-100 text-red-800";
       default:
         return "bg-gray-100 text-gray-800";
@@ -82,11 +82,11 @@ export default function PresetGrids({ onLoadPreset }: PresetGridsProps) {
     <div className="space-y-4">
       <div className="text-center mb-6">
         <h3 className="text-lg font-semibold text-gray-800 mb-2">
-          Choose a Preset Grid
+          Elige una Cuadrícula Predefinida
         </h3>
         <p className="text-sm text-gray-600">
-          Select a pre-designed forest to get started quickly, or use them as
-          inspiration for your own grids.
+          Selecciona un bosque predefinido para comenzar rápido o utilízalos como
+          inspiración para tus propias cuadrículas.
         </p>
       </div>
 
@@ -105,13 +105,13 @@ export default function PresetGrids({ onLoadPreset }: PresetGridsProps) {
             <CardContent className="space-y-4">
               <div className="flex items-center gap-4 text-sm text-gray-600">
                 <span>
-                  Grid Size:{" "}
+                  Tamaño:{" "}
                   <strong>
                     {preset.grid.length}×{preset.grid[0].length}
                   </strong>
                 </span>
                 <span>
-                  Starting Energy: <strong>{preset.energy}</strong>
+                  Energía Inicial: <strong>{preset.energy}</strong>
                 </span>
               </div>
 
@@ -148,7 +148,7 @@ export default function PresetGrids({ onLoadPreset }: PresetGridsProps) {
                 variant="outline"
               >
                 <Play className="w-4 h-4 mr-2" />
-                Load This Grid
+                Cargar Esta Cuadrícula
               </Button>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary
- translate UI text to Spanish
- update preset names and descriptions to Spanish
- set HTML `lang` to `es` and update metadata

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f562b63a88330a6329c2abc25e5fc